### PR TITLE
Github URL and removing src from build publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yaask",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "yaask",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Make your yaml configurable with interactive configurations!",
+  "url": "https://github.com/ro31337/yaask",
   "main": "build/app.js",
   "bin": {
-    "yaask": "./build/app.js"
+    "yaask": "build/app.js"
   },
+  "files": [
+    "build/",
+    "LICENSE"
+  ],
   "scripts": {
     "clean": "rm -rf ./build && mkdir ./build",
     "build": "npm run clean && babel -d ./build ./src -s false",


### PR DESCRIPTION
 - Links to Github to find from npm page
 - Uses the "files" array to only include built files in the published
 package. Before, if you `npm install yaask; ls node_modules/yaask` you
 would get the full src directory. Now you only get the build directory
 - Version bump for convenience :)